### PR TITLE
bump rewrite-core dependency to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile 'com.netflix.devinsight.rewrite:rewrite-core:1.2.0'
+    compile 'com.netflix.devinsight.rewrite:rewrite-core:1.3.0'
     compile 'eu.infomas:annotation-detector:latest.release'
 
     testCompile 'junit:junit:4.+'


### PR DESCRIPTION
Otherwise, I need to force the version when using rewrite-gradle 0.3.2 with `@AutoRewrite` rules that are written against rewrite-core 1.3.0.