### PR TITLE
allow multiple rules to be applied at once

### DIFF
--- a/src/main/kotlin/io/spring/rewrite/gradle/RewritePlugin.kt
+++ b/src/main/kotlin/io/spring/rewrite/gradle/RewritePlugin.kt
@@ -60,12 +60,12 @@ abstract class AbstractRewriteTask : DefaultTask() {
             val runners = RewriteScanner(ss.compileClasspath).rewriteRunnersOnClasspath()
 
             asts.forEach { cu ->
+                val refactor = cu.refactor()
                 runners.forEach { (rule, op) ->
-                    val refactor = cu.refactor()
                     op.invoke(refactor)
-                    afterRefactor.invoke(refactor)
                     stats.merge(rule, refactor.stats().values.sum(), Int::plus)
                 }
+                afterRefactor.invoke(refactor)
             }
 
             stats


### PR DESCRIPTION
This allows multiple rules to be applied at once, which is useful if each rule isn't guaranteed to leave the repo in a compiling state (so you can't just run `fixSourceLint` twice with different dependencies each time).